### PR TITLE
Disabled functionality on password fields with placeholders.

### DIFF
--- a/lib/tai-placeholder.js
+++ b/lib/tai-placeholder.js
@@ -47,6 +47,10 @@
                 link: function ($scope, $element, $attributes, $controller) {
                     var className, currentValue, text;
 
+                    function isPasswordField() {
+                        return $element.prop("type") && $element.prop("type").toLowerCase() === "password";
+                    }
+
                     text = $attributes[propName];
                     className = $attributes[propName + "Class"] || propName;
 
@@ -80,6 +84,10 @@
                         // This determines if we show placeholder text or not
                         // when there was a change detected on scope.
                         $controller.$formatters.unshift(function (val) {
+                            // do nothing on password fields, as they would be filled with asterisks.
+                            if (isPasswordField()) {
+                                val = text = "";
+                            }
                             // Show placeholder text instead of empty value
                             return val || text;
                         });

--- a/lib/tai-placeholder.spec.js
+++ b/lib/tai-placeholder.spec.js
@@ -83,5 +83,27 @@
                 });
             });
         });
+
+        describe('don\'t handle password fields', function () {
+            var element, scope;
+
+            beforeEach(module('taiPlaceholder'));
+            beforeEach(inject(function ($rootScope) {
+                scope = $rootScope.$new();
+            }));
+
+            it('even if it has a placeholder', inject(function ($compile) {
+                element = $compile('<input type="password" ng-model="something" placeholder="XYZ" />')(scope);
+                scope.$apply(function () {
+                    scope.something = "password";
+                });
+
+                if (!placeholderSupported) {
+                    expect(element.val()).toBe('');
+                    expect(element.hasClass('placeholder')).toBe(false);
+                }
+            }));
+
+        });
     });
 }());


### PR DESCRIPTION
As the HTML5 standard allows human readable text in placeholder attributes, putting a value with javascript in it results in *****. That's not very user friendly. ;)
