### PR TITLE
Add main entry to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "engines": {
         "node": ">= 0.8.0"
     },
+    "main": "./lib/tai-placeholder.js",
     "dependencies": {},
     "devDependencies": {
         "bower": "*",


### PR DESCRIPTION
Allows loaders like SystemJS and Browserify to correctly load module without any additional configuration.
